### PR TITLE
Fix getting table schema name

### DIFF
--- a/.github/workflows/test-platforms.yaml
+++ b/.github/workflows/test-platforms.yaml
@@ -49,7 +49,7 @@ jobs:
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: Install Composer dependencies (highest)
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
                   composer-options: --prefer-dist --prefer-stable
@@ -98,7 +98,7 @@ jobs:
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: Install Composer dependencies (highest)
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v2
               with:
                   dependency-versions: highest
                   composer-options: --prefer-dist --prefer-stable

--- a/src/AuditConfiguration.php
+++ b/src/AuditConfiguration.php
@@ -72,7 +72,7 @@ class AuditConfiguration
     {
         $tableName = $metadata->getTableName();
 
-        if (null !== $metadata->getSchemaName()) {
+        if (null !== $metadata->getSchemaName() && '' !== $metadata->getSchemaName()) {
             $tableName = $metadata->getSchemaName().'.'.$tableName;
         }
 


### PR DESCRIPTION
https://lendable-uk.atlassian.net/browse/MSP-499

Some bundles set the table schema to a blank string instead of `null` which then results in this bundle blowing up due to running broken SQL queries like `INSERT INTO .foo` (instead of `INSERT INTO foo`).