### PR TITLE
chore(DEVOPS-7314): migrate to gha scale sets

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
     php-cs-fixer:
         name: PHP-CS-Fixer
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         steps:
             - name: Checkout
@@ -45,7 +45,7 @@ jobs:
     composer:
         name: Composer
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         steps:
             - name: Checkout
@@ -66,7 +66,7 @@ jobs:
     yaml-files:
         name: YAML files
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         steps:
             - name: Checkout
@@ -81,7 +81,7 @@ jobs:
     xml-files:
         name: XML files
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         steps:
             - name: Checkout

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -20,7 +20,7 @@ jobs:
     phpstan:
         name: PHPStan
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         steps:
             - name: Checkout
@@ -45,7 +45,7 @@ jobs:
     psalm:
         name: Psalm
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         steps:
             - name: Checkout code
@@ -70,7 +70,7 @@ jobs:
     rector:
         name: Rector
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         steps:
             - name: Checkout code

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
     stale:
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         steps:
             - name: Close stale issues and pull requests

--- a/.github/workflows/test-platforms.yaml
+++ b/.github/workflows/test-platforms.yaml
@@ -11,7 +11,7 @@ jobs:
     test-mysql:
         name: PHP ${{ matrix.php-version }} + MySQL + highest
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         continue-on-error: false
 
@@ -60,7 +60,7 @@ jobs:
     test-postgres:
         name: PHP ${{ matrix.php-version }} + PostgreSQL + highest
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         continue-on-error: false
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
     test:
         name: PHP ${{ matrix.php-version }} + ${{ matrix.dependencies }} + ${{ matrix.variant }}
 
-        runs-on: ubuntu-latest
+        runs-on: [ 'lendable-medium-dind-x64-linux' ]
 
         continue-on-error: ${{ matrix.allowed-to-fail }}
 


### PR DESCRIPTION
[DEVOPS-7314]

We are migrating to GHA ScaleSets - the new version of self-hosted GitHub runners. Please verify the changes:
1. It is using only single label for targeting like that - `[ 'lendable-small-arm64-linux' ]` . If possible follow literally for better future migration experience.
2. For each runner type we have both `arm64` and `x64` variants. Please try to run any generic jobs on arm runners. They offer better price to performance ratio.
3. You can run standard and container jobs on those runners. If you have problems - `#devops-help-desk`. Last resort Dind type runners.
4. Use Dind types `[ 'lendable-medium-dind-x64-linux' ]` only when you need to run `docker`. If your container jobs don't run in standard you can try them here.


[DEVOPS-7314]: https://lendable-uk.atlassian.net/browse/DEVOPS-7314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ